### PR TITLE
ci: add gitlint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
       args: [ --fix, --extend-select, I ]
     # Run the formatter.
     - id: ruff-format
+ - repo: https://github.com/jorisroovers/gitlint
+   rev: v0.19.1
+   hooks:
+     - id: gitlint
+     - id: gitlint-ci


### PR DESCRIPTION
Add Gitlint to -precommit configuration.

Gitlint needs this installation line:
pre-commit install --hook-type commit-msg