### PR TITLE
ci: upload junit report to artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check style of package
         run: pre-commit run --all
       - name: Run tests
-        run: pytest tests
+        run: pytest --junit-xml=junit-reports/test_results.xml tests
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Upload test report to artifacts.

I think an additional argument is required to create the test report at the correct location. Previously, no XML file was uploaded.