### PR TITLE
mr: Handle upon 'or' case more properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ There are some implementation details and restrictions to consider when using:
 
 * Only 'if then' and pure expressions are supported in the 'Satisfy' clause.
 * Formatting of printed requirements is fine, but not pretty. This could be improved in newer versions if needed.
+* Different events in the 'Upon' clause can only be separated by '|' ('or') and are split into different test cases.
 
 ## Contributing
 

--- a/src/fretish_robot/generate_robot.py
+++ b/src/fretish_robot/generate_robot.py
@@ -65,20 +65,13 @@ def _extract_scope_modes(fret_req: FRETRequirement) -> list[tuple[str | None, TA
         return [(None, "always")]
 
 
-def _extract_events(fret_req: FRETRequirement) -> list[tuple[str | None, TAG]]:
-    event = fret_req.trigger_event
+# TODO: This currently can only handle '|' separated events,
+# we will need a more complex extraction and split code when we want
+# to also support '&'
+def _extract_events(event: str | None) -> list[tuple[str | None, TAG]]:
     if event is not None:
-        if event.startswith("(") and event.endswith(")"):
-            result = []
-            different_events = event[1:-1].split("|")
-            for diff_event in different_events:
-                diff_event = diff_event.strip()
-                result.append((diff_event, diff_event))
-            return result
-        else:
-            return [(event, event)]
-        ...
-
+        all_events = re.findall(r"\w+", event)
+        return list(map(lambda x: (x, x), all_events))
     else:
         return [(None, "always")]
 
@@ -92,7 +85,7 @@ def _construct_taglist(req_id: str, mode: str, event: str) -> list[tuple[str, st
 def _add_single_test(suite: TestSuite, fret_req: FRETRequirement) -> None:
     req_id = fret_req.req_id
     extracted_scopes = _extract_scope_modes(fret_req)
-    extracted_events = _extract_events(fret_req)
+    extracted_events = _extract_events(fret_req.trigger_event)
 
     test_number = 0
 

--- a/tests/test_generate_robot.py
+++ b/tests/test_generate_robot.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from fretish_robot.generate_robot import _prefix_vars, _to_python_expr
+from fretish_robot.generate_robot import _extract_events, _prefix_vars, _to_python_expr
 
 TEST_EXPR = "a != 1 & b = 1 | c = 4 ^ 3 - 1 & b = 2 | d <= a"
 EXPECTED_PYTHON = "a != 1 and b == 1 or c == 4 ** 3 - 1 and b == 2 or d <= a"
@@ -73,3 +73,16 @@ def test__prefix_vars__string_with_multiple_vars__all_prefixed():
     result = _prefix_vars(EXPECTED_PYTHON, ["a", "b", "c", "d"])
 
     assert result == EXPECTED_PREFIXED
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        ("a", [("a", "a")]),
+        ("(( a | b) |c_d)", [("a", "a"), ("b", "b"), ("c_d", "c_d")]),
+    ],
+)
+def test___extract_events__different_inputes__correctly_extracted(expr, expected):
+    result = _extract_events(expr)
+
+    assert result == expected


### PR DESCRIPTION
When given 3 or more 'or' events in the 'upon' clause, the regular_condition_unexp_pt splits (a|b|c) into ((a|b)|c), surrounded by brackets. This was not handled properly, the result contained e.g. (a with bracket.

This shows that the current split behaviour is not sufficient for cases where all of FRET allowed features is correctly transformed. While sufficient for simpler cases and the features we used, there is still work to do for a proper transformation case.