### PR TITLE
ci: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
     - id: trailing-whitespace
     - id: check-merge-conflict
     - id: end-of-file-fixer
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.6.4
+  rev: v0.6.9
   hooks:
     # Run the linter.
     - id: ruff


### PR DESCRIPTION
Update `pre-commit` to latest version to get rid of the [following warning in GitHub actions](https://github.com/ZEISS/fretish_robot/actions/runs/11200917812/job/31135217002#step:5:13):
```
Warning: repo https://github.com/pre-commit/pre-commit-hooks uses deprecated stage names (commit, push) which will be removed in a future version.
Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks will fix this.
```

This PR is the result of running `pre-commit autoupdate`.